### PR TITLE
Set up CI build pipeline with translation validation and ZIP generation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,7 +51,7 @@ jobs:
         zip -r courtly.zip src
 
     - name: Upload artifact
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: courtly-build-${{ github.run_number }}
         path: courtly.zip

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,57 @@
+name: Build and Validate
+
+on:
+  push:
+    branches:
+      - '*'
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v3
+
+    - name: Install gettext
+      run: sudo apt-get update && sudo apt-get install -y gettext
+
+    - name: Compile .po files to .mo
+      working-directory: src/languages
+      run: |
+        set -e
+        for file in *.po; do
+          msgfmt "$file" -o "${file%.po}.mo"
+        done
+
+    - name: Validate translations
+      working-directory: src/languages
+      run: |
+        set -e
+        po_count=$(ls -1 *.po | wc -l)
+        mo_count=$(ls -1 *.mo | wc -l)
+        if [ "$po_count" -ne "$mo_count" ]; then
+          echo "Mismatch between .po and .mo file counts. Failing build."
+          exit 1
+        fi
+
+    - name: Stub PHPUnit tests
+      run: |
+        set -e
+        echo "PHPUnit tests are currently stubbed."
+        # Uncomment the following line to enable PHPUnit tests in the future
+        # ./vendor/bin/phpunit
+
+    - name: Generate ZIP artifact
+      run: |
+        set -e
+        zip -r courtly.zip src
+
+    - name: Upload artifact
+      uses: actions/upload-artifact@v3
+      with:
+        name: courtly-build-${{ github.run_number }}
+        path: courtly.zip


### PR DESCRIPTION
- GitHub Actions workflow `build.yml` running on all pushes and PRs
- `.mo` compilation from `.po` using `msgfmt`
- Build fails if `.mo` and `.po` counts don’t match
- Stub PHPUnit test step (for future use)
- ZIP of the plugin (`courtly.zip`) included as build artifact
- Switched `upload-artifact` action to v4 (stable)